### PR TITLE
Add version to deployment name

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.service | quote }}
+  name: {{ (print .Values.service "-v" .Values.version) | quote }}
   labels:
     app.kubernetes.io/name: {{ .Values.service | quote }}
     app.kubernetes.io/part-of: {{ .Values.system | quote }}


### PR DESCRIPTION
Putting the version in the generated deployment name allows you to deploy a new major version side-by-side. It also prevents the immutability error seen in #1.